### PR TITLE
I fixed Error initializing block database.

### DIFF
--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -471,7 +471,7 @@ bool CBlockTreeDB::LoadBlockIndexGuts(const Consensus::Params& consensusParams, 
             CDiskBlockIndex diskindex;
             if (pcursor->GetValue(diskindex)) {
                 // Construct block index object
-                CBlockIndex* pindexNew = insertBlockIndex(diskindex.GetBlockHash());
+                CBlockIndex* pindexNew = insertBlockIndex(key.second);
                 pindexNew->pprev          = insertBlockIndex(diskindex.hashPrev);
                 pindexNew->nHeight        = diskindex.nHeight;
                 pindexNew->nFile          = diskindex.nFile;


### PR DESCRIPTION
mapBlockIndex has WorkHashes like keys, so after the node restarted, mapBlockIndex had keys different than before the node exit. It was a cause of initializing block database error.